### PR TITLE
Enable serial console ttyS0

### DIFF
--- a/grub/defaults.yaml
+++ b/grub/defaults.yaml
@@ -2,14 +2,11 @@ grub:
   lookup:
     pkgs:
       - grub2
-      - grubby
-    config_file: /etc/default/grub
-    update_grub_cmd: test -f /etc/grub2.cfg && grub2-mkconfig -o /etc/grub2.cfg || test -f /etc/grub2-efi.cfg && grub2-mkconfig -o /etc/grub2-efi.cfg
+    default_grub: /etc/default/grub
+    grub_config: /boot/grub2/grub.cfg 
   config:
     changes:
       GRUB_TIMEOUT: 2
-      GRUB_SERIAL_COMMAND: "serial --unit=0 --speed=115200" 
+      GRUB_SERIAL_COMMAND: "serial --unit=0 --speed=115200"
       GRUB_CMDLINE_LINUX_DEFAULT: "splash=silent quiet showopts elevator=noop console=tty0 console=ttyS0,115200n8 vga=788" 
       GRUB_CMDLINE_LINUX_RECOVERY: "showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe console=tty0 console=ttyS0,115200n8" 
-
-

--- a/grub/map.jinja
+++ b/grub/map.jinja
@@ -7,8 +7,8 @@
     'CentOS': {
       'pkgs': [ 'grub2-efi-x64', 'grub2-tools-extra' ],
     },
-    'Suse': {
-      'pkgs': [ 'grub2', 'grub2-x86_64-efi', 'grub2-i386-pc', 'grub2-systemd-sleep-plugin' ],
+    'SUSE': {
+      'pkgs': [ 'grub2-x86_64-efi', 'grub2-i386-pc', 'grub2-systemd-sleep-plugin' ],
     },
   }, grain='os', merge=salt['pillar.get']('grub:lookup')) %}
 


### PR DESCRIPTION
This works for SLES12SP3, tested here:
```
----------
          ID: grub
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 13:03:07.297255
    Duration: 24.039 ms
     Changes:
----------
          ID: update-grub-config
    Function: augeas.change
      Result: True
     Comment: No changes made
     Started: 13:03:07.333441
    Duration: 70.032 ms
     Changes:
----------
          ID: grub-mkconfig
    Function: cmd.run
        Name: test -f /boot/grub2/grub.cfg  && grub2-mkconfig -o /boot/grub2/grub.cfg
      Result: True
     Comment: Command "test -f /boot/grub2/grub.cfg  && grub2-mkconfig -o /boot/grub2/grub.cfg" run
     Started: 13:03:07.414037
    Duration: 2312.304 ms
     Changes:
              ----------
              pid:
                  2957
              retcode:
                  0
              stderr:
                  Generating grub configuration file ...
                  Found theme: /boot/grub2/themes/SLE/theme.txt
                  Found linux image: /boot/vmlinuz-4.4.82-6.9-default
                  Found initrd image: /boot/initrd-4.4.82-6.9-default
                  Found linux image: /boot/vmlinuz-4.4.73-5-default
                  Found initrd image: /boot/initrd-4.4.73-5-default
                  done
              stdout:
----------
          ID: serial-getty
    Function: file.append
        Name: /etc/securetty
      Result: True
     Comment: File /etc/securetty is in correct state
     Started: 13:03:09.726640
    Duration: 12.441 ms
     Changes:
----------
          ID: serial-getty@ttyS0
    Function: service.running
      Result: True
     Comment: The service serial-getty@ttyS0 is already running
     Started: 13:03:09.739224
    Duration: 40.447 ms
     Changes:

Summary for pepper-2.suse.cz
-------------
Succeeded: 15 (changed=1)
```